### PR TITLE
disable S3LocalstackTest

### DIFF
--- a/src/test/java/io/github/sullis/s3/playground/S3LocalstackTest.java
+++ b/src/test/java/io/github/sullis/s3/playground/S3LocalstackTest.java
@@ -1,5 +1,6 @@
 package io.github.sullis.s3.playground;
 
+import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -7,6 +8,7 @@ import org.testcontainers.utility.DockerImageName;
 
 
 @Testcontainers
+@Disabled
 public class S3LocalstackTest extends AbstractS3Test {
   @Container
   private static final LocalStackContainer LOCALSTACK = new LocalStackContainer(DockerImageName.parse("localstack/localstack:s3-latest"))


### PR DESCRIPTION
# Motivation

Localstack and AWS SDK

```
java.util.concurrent.ExecutionException: 

software.amazon.awssdk.services.s3.model.InvalidRequestException: 

Checksum Type mismatch occurred, 
expected checksum Type: null, actual checksum 
Type: crc32 (Service: S3, Status Code: 400
```
